### PR TITLE
fix: only preg escape the url characters

### DIFF
--- a/packages/cors/src/index.js
+++ b/packages/cors/src/index.js
@@ -13,13 +13,13 @@ const apexDomain =
     : false;
 
 const validOrigins = apexDomain
-  ? [new RegExp(RegexEscape(`^${FRONTEND_URL}$`)), new RegExp(RegexEscape(`.${apexDomain}$`))]
+  ? [new RegExp(`^${RegexEscape(FRONTEND_URL)}$`), new RegExp(`.*\.${RegexEscape(apexDomain)}$`)]
   : [];
 
 const sdkOrigins = SDK_CORS_ORIGINS
   ? SDK_CORS_ORIGINS.replace(/\s/g, '')
       .split(',')
-      .map((origin) => new RegExp(RegexEscape(`^${origin}$`)))
+      .map((origin) => new RegExp(`^${RegexEscape(origin)}$`))
   : [];
 
 module.exports = (req, callback) => {


### PR DESCRIPTION
I didn't pay close enough attention to the other PR. Need to only escape the URL that has the special characters.